### PR TITLE
Custom Authentication Backend

### DIFF
--- a/src/scrum_scrum/scrum_scrum/settings.py
+++ b/src/scrum_scrum/scrum_scrum/settings.py
@@ -111,6 +111,11 @@ AUTH_PASSWORD_VALIDATORS = [
 #   Override Django's base user model for authentication
 AUTH_USER_MODEL = 'scrum_scrum_api.ScrumScrumUser'
 
+#   Override Django's default authentication backend
+AUTHENTICATION_BACKENDS = (
+    'scrum_scrum_api.backends.ScrumScrumAuthBackend',
+)
+
 #   REST_FRAMEWORK settings
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (

--- a/src/scrum_scrum/scrum_scrum_api/backends.py
+++ b/src/scrum_scrum/scrum_scrum_api/backends.py
@@ -1,0 +1,37 @@
+"""
+This file houses the custom authentication backend that allows users to
+authenticate with either email or username.
+"""
+
+from django.contrib.auth.backends import ModelBackend
+from django.contrib.auth import get_user_model
+from django.db.models import Q
+from rest_framework import exceptions
+
+from .models import ScrumScrumUser
+
+class ScrumScrumAuthBackend(ModelBackend):
+
+    def authenticate(self, username=None, password=None, **kwargs):
+        """Attempt to authenticate the user with the provided credentials."""
+
+        user_model = get_user_model()
+
+        if username is None:
+            username = kwargs.get(user_model.USERNAME_FIELD)
+
+        users = user_model._default_manager.filter(
+            Q(**{user_model.USERNAME_FIELD: username}) |
+            Q(email__iexact=username)
+        )
+
+        if not users:
+            raise exceptions.AuthenticationFailed(
+                'Username or email provided was not found.')
+
+        for user in users:
+            if user.check_password(password):
+                return user
+
+        raise exceptions.AuthenticationFailed(
+            'Could not authenticate with provided credentials.')


### PR DESCRIPTION
This change introduces a custom auth backend that will allow
users to attempt to authenticate with either their username OR
their email. Failed auth attempts will return a 401 Unauthorized
HTTP status code with a descriptive message: either the username
or email wasn't found, or the credentials were incorrect.